### PR TITLE
Fix Update-QlikProxy

### DIFF
--- a/Qlik-Cli.psm1
+++ b/Qlik-Cli.psm1
@@ -1620,14 +1620,11 @@ function Update-QlikProxy {
     [Int]$MaxHeaderLines,
 
     [ValidateRange(1,65536)]
-    [Int]$RestListenPort,
-
-    [HashTable]$params
-
+    [Int]$RestListenPort
   )
 
   PROCESS {
-    $proxy = Get-QlikProxy -Id $id -params $params
+    $proxy = Get-QlikProxy -Id $id
     $proxy.settings.listenPort = $listenPort
     $proxy.settings.allowHttp = $allowHttp
     $proxy.settings.unencryptedListenPort = $unencryptedListenPort
@@ -1640,7 +1637,7 @@ function Update-QlikProxy {
     $proxy.settings.maxHeaderLines = $maxHeaderLines
     $proxy.settings.restListenPort = $restListenPort
     $json = $proxy | ConvertTo-Json -Compress -Depth 5
-    return Put-RestUri -Path "/qrs/proxyservice/$id" -Body $json -Params $params
+    return Put-RestUri -Path "/qrs/proxyservice/$id" $json
   }
 }
 

--- a/Qlik-Cli.psm1
+++ b/Qlik-Cli.psm1
@@ -1625,17 +1625,17 @@ function Update-QlikProxy {
 
   PROCESS {
     $proxy = Get-QlikProxy -Id $id
-    $proxy.settings.listenPort = $listenPort
+    if ($listenPort) { $proxy.settings.listenPort = $listenPort }
     $proxy.settings.allowHttp = $allowHttp
-    $proxy.settings.unencryptedListenPort = $unencryptedListenPort
-    $proxy.settings.authenticationListenPort = $authenticationListenPort
+    if ($unencryptedListenPort) { $proxy.settings.unencryptedListenPort = $unencryptedListenPort }
+    if ($authenticationListenPort) { $proxy.settings.authenticationListenPort = $authenticationListenPort }
     $proxy.settings.kerberosAuthentication = $kerberosAuthentication
-    $proxy.settings.unencryptedAuthenticationListenPort = $unencryptedAuthenticationListenPort
-    if($sslBrowserCertificateThumbprint) { $proxy.settings.sslBrowserCertificateThumbprint = $sslBrowserCertificateThumbprint }
-    $proxy.settings.keepAliveTimeoutSeconds = $keepAliveTimeoutSeconds
-    $proxy.settings.maxHeaderSizeBytes = $maxHeaderSizeBytes
-    $proxy.settings.maxHeaderLines = $maxHeaderLines
-    $proxy.settings.restListenPort = $restListenPort
+    if ($unencryptedAuthenticationListenPort) { $proxy.settings.unencryptedAuthenticationListenPort = $unencryptedAuthenticationListenPort }
+    if ($sslBrowserCertificateThumbprint) { $proxy.settings.sslBrowserCertificateThumbprint = $sslBrowserCertificateThumbprint }
+    if ($keepAliveTimeoutSeconds) { $proxy.settings.keepAliveTimeoutSeconds = $keepAliveTimeoutSeconds }
+    if ($maxHeaderSizeBytes) { $proxy.settings.maxHeaderSizeBytes = $maxHeaderSizeBytes }
+    if ($maxHeaderLines) { $proxy.settings.maxHeaderLines = $maxHeaderLines }
+    if ($restListenPort) { $proxy.settings.restListenPort = $restListenPort }
     $json = $proxy | ConvertTo-Json -Compress -Depth 5
     return Put-RestUri -Path "/qrs/proxyservice/$id" $json
   }


### PR DESCRIPTION
Fix for Update-QlikProxy. I made two changes.

- "params" parameter was not supported by "Put-RestUri" and "Get-QlikProxy". It threw an error.
- avoid overwriting of the settings with "0"