### PR TITLE
Bug fix for Update-QlikApp function

### DIFF
--- a/Qlik-Cli.psm1
+++ b/Qlik-Cli.psm1
@@ -1694,14 +1694,14 @@ function Update-QlikApp {
   )
 
   PROCESS {
-    $app = Get-QlikApp $id
+    $app = Get-QlikApp $id -raw
     If( $name ) { $app.name = $name }
     If( $description ) { $app.description = $description }
     If( $customProperties ) {
       $prop = @(
         $customProperties | foreach {
           $val = $_ -Split "="
-          $p = Get-QlikCustomProperty -filter "name eq '$($val[0])'"
+          $p = Get-QlikCustomProperty -filter "name eq '$($val[0])'" -raw
           @{
             value = ($p.choiceValues -eq $val[1])[0]
             definition = $p


### PR DESCRIPTION
- Fixed a bug that doesn't allow you to update any application due to incompatible date format. (API 3.0)
- Added -raw parameter to Get-QlikApp and Get-QlikCustomProperty calls
  from the Update-QlikApp function.
- Tested with Qlik Sense API 3.0