### PR TITLE
Fix: delete task through the selections system

### DIFF
--- a/resources/task.ps1
+++ b/resources/task.ps1
@@ -192,7 +192,20 @@ function Remove-QlikTask {
   )
 
   PROCESS {
-    return Invoke-QlikDelete "/qrs/task/$id"
+    $taskType = "ReloadTask"
+    $json = (@{
+      items = @(
+        @{
+          type = $taskType;
+          objectID = $id
+        }
+      )
+    } | ConvertTo-Json -Compress -Depth 10)
+    $selection = Invoke-QlikPost "/qrs/selection" $json
+    $result = Invoke-QlikDelete "/qrs/selection/$($selection.Id)/$taskType"
+    Invoke-QlikDelete "/qrs/selection/$($selection.Id)" | Out-Null
+
+    return $result
   }
 }
 


### PR DESCRIPTION
DELETE /qrs/task/$id is not working anymore with QS Feb 2018, at least. The proper way seems to be through "selections".

Other objects deletion should be checked too, they may not work anymore.