### PR TITLE
New-QlikVirtualProxy Improvements

### DIFF
--- a/resources/proxy.ps1
+++ b/resources/proxy.ps1
@@ -220,18 +220,6 @@ function Remove-QlikVirtualProxy {
   }
 }
 
-function Remove-QlikVirtualProxy {
-  [CmdletBinding()]
-  param (
-    [parameter(Position=0,ValueFromPipelinebyPropertyName=$true)]
-    [string]$id
-  )
-
-  PROCESS {
-    return Invoke-QlikDelete "/qrs/virtualproxyconfig/$id"
-  }
-}
-
 function Update-QlikProxy {
   [CmdletBinding()]
   param (

--- a/resources/proxy.ps1
+++ b/resources/proxy.ps1
@@ -115,97 +115,108 @@ function Get-QlikVirtualProxy {
 }
 
 function New-QlikVirtualProxy {
+    [CmdletBinding()]
+    param (
+      [parameter(Position=0)]
+      [string]$prefix,
+  
+      [parameter(Mandatory=$true,Position=1)]
+      [string]$description,
+  
+      [parameter(Mandatory=$true,Position=2)]
+      [alias("cookie")]
+      [string]$sessionCookieHeaderName,
+  
+      [alias("authUri")]
+      [string]$authenticationModuleRedirectUri,
+  
+      [alias("engine")]
+      [string[]]$loadBalancingServerNodes = "",
+  
+      [alias("wsorigin")]
+      [string[]]$websocketCrossOriginWhiteList = "",
+  
+      [ValidateSet("ticket","static","dynamic","saml","jwt", IgnoreCase=$false)]
+      [String]$authenticationMethod="ticket",
+  
+      [String]$samlMetadataIdP="",
+  
+      [String]$samlHostUri="",
+  
+      [String]$samlEntityId="",
+  
+      [String]$samlAttributeUserId="",
+  
+      [String]$samlAttributeUserDirectory="",
+
+      [String]$headerAuthenticationMode="0",
+
+      [String]$headerAuthenticationHeaderName="",
+
+      [String]$headerAuthenticationStaticUserDirectory="",
+
+      [String]$headerAuthenticationDynamicUserDirectory="",
+
+      [int]$anonymousAccessMode="",
+  
+      [Int]$sessionInactivityTimeout = 30
+    )
+  
+    PROCESS {
+      If( $loadBalancingServerNodes ) {
+        $engines = @(
+          $loadBalancingServerNodes | foreach {
+            If( $_ -match $script:guid ) {
+              @{ id = $_ }
+            } else {
+              $eid = Get-QlikNode -filter "hostname eq '$_'"
+              @{ id = $eid.id }
+            }
+          }
+        )
+      } else {
+        $engines = @()
+      }
+      $authenticationMethodCode = switch ($authenticationMethod) {
+        "ticket"  { 0 }
+        "static"  { 1 }
+        "dynamic" { 2 }
+        "saml"    { 3 }
+        "jwt"     { 4 }
+      }
+  
+      $json = (@{
+        prefix=$prefix;
+        description=$description;
+        authenticationModuleRedirectUri=$authenticationModuleRedirectUri;
+        loadBalancingServerNodes=$engines;
+        sessionCookieHeaderName=$sessionCookieHeaderName;
+        websocketCrossOriginWhiteList=$websocketCrossOriginWhiteList;
+        sessionInactivityTimeout=$sessionInactivityTimeout;
+        authenticationMethod=$authenticationMethodCode;
+        samlMetadataIdP=$samlMetadataIdP;
+        samlHostUri=$samlHostUri;
+        samlEntityId=$samlEntityId;
+        samlAttributeUserId=$samlAttributeUserId;
+        samlAttributeUserDirectory=$samlAttributeUserDirectory;
+        headerAuthenticationMode=$headerAuthenticationMode;
+        headerAuthenticationHeaderName=$headerAuthenticationHeaderName;
+        headerAuthenticationDynamicUserDirectory=$headerAuthenticationDynamicUserDirectory;
+      } | ConvertTo-Json -Compress -Depth 10)
+      echo $json
+      return Invoke-QlikPost "/qrs/virtualproxyconfig" $json
+    }
+  }
+
+function Remove-QlikVirtualProxy {
   [CmdletBinding()]
   param (
-    [parameter(Position=0)]
-    [string]$prefix,
-
-    [parameter(Mandatory=$true,Position=1)]
-    [string]$description,
-
-    [parameter(Mandatory=$true,Position=2)]
-    [alias("cookie")]
-    [string]$sessionCookieHeaderName,
-
-    [alias("authUri")]
-    [string]$authenticationModuleRedirectUri,
-
-    [alias("engine")]
-    [string[]]$loadBalancingServerNodes = "",
-
-    [alias("wsorigin")]
-    [string[]]$websocketCrossOriginWhiteList = "",
-
-    [ValidateSet("ticket","static","dynamic","saml","jwt", IgnoreCase=$false)]
-    [String]$authenticationMethod="ticket",
-
-    [String]$samlMetadataIdP="",
-
-    [String]$samlHostUri="",
-
-    [String]$samlEntityId="",
-
-    [String]$samlAttributeUserId="",
-
-    [String]$samlAttributeUserDirectory="",
-
-    [hashtable[]]$samlAttributeMap,
-
-    [switch]$samlSlo,
-
-    [ValidateSet("sha1","sha256")]
-    [String]$samlSigningAlgorithm="sha1",
-
-    [Int]$sessionInactivityTimeout = 30
+    [parameter(Position=0,ValueFromPipelinebyPropertyName=$true)]
+    [string]$id
   )
 
   PROCESS {
-    If( $loadBalancingServerNodes ) {
-      $engines = @(
-        $loadBalancingServerNodes | foreach {
-          If( $_ -match $script:guid ) {
-            @{ id = $_ }
-          } else {
-            $eid = Get-QlikNode -filter "hostname eq '$_'"
-            @{ id = $eid.id }
-          }
-        }
-      )
-    } else {
-      $engines = @()
-    }
-    $authenticationMethodCode = switch ($authenticationMethod) {
-      "ticket"  { 0 }
-      "static"  { 1 }
-      "dynamic" { 2 }
-      "saml"    { 3 }
-      "jwt"     { 4 }
-    }
-    $samlSigningAlgorithmCode = switch ($samlSigningAlgorithm) {
-      "sha1"   { 0 }
-      "sha256" { 1 }
-    }
-
-    $json = (@{
-      prefix=$prefix;
-      description=$description;
-      authenticationModuleRedirectUri=$authenticationModuleRedirectUri;
-      loadBalancingServerNodes=$engines;
-      sessionCookieHeaderName=$sessionCookieHeaderName;
-      websocketCrossOriginWhiteList=$websocketCrossOriginWhiteList;
-      sessionInactivityTimeout=$sessionInactivityTimeout;
-      authenticationMethod=$authenticationMethodCode;
-      samlMetadataIdP=$samlMetadataIdP;
-      samlHostUri=$samlHostUri;
-      samlEntityId=$samlEntityId;
-      samlAttributeUserId=$samlAttributeUserId;
-      samlAttributeUserDirectory=$samlAttributeUserDirectory;
-      samlAttributeMap=$samlAttributeMap;
-      samlSlo=$samlSlo.IsPresent;
-      samlAttributeSigningAlgorithm=$samlSigningAlgorithmCode;
-    } | ConvertTo-Json -Compress -Depth 10)
-
-    return Invoke-QlikPost "/qrs/virtualproxyconfig" $json
+    return Invoke-QlikDelete "/qrs/virtualproxyconfig/$id"
   }
 }
 


### PR DESCRIPTION
Added: Support for Header authentication (dynamic and static) to New-QlikVirtualProxy.

Sample usage: New-QlikVirtualProxy -prefix foo -description "header demo" -loadBalancingServerNodes $(Get-QlikNode  | Where-Object {$_.hostName -like "*$($FQDN)*"}).id -authenticationMethod dynamic -sessionCookieHeaderName X-Qlik-foo -headerAuthenticationHeaderName hdr -headerAuthenticationDynamicUserDirectory '$ud\\$id'