### PR TITLE
Update-QlikDataConnections

### DIFF
--- a/resources/app.ps1
+++ b/resources/app.ps1
@@ -24,19 +24,21 @@ function Export-QlikApp {
     [parameter(Mandatory=$true,ValueFromPipeline=$True,ValueFromPipelinebyPropertyName=$True,Position=0)]
     [string]$id,
     [parameter(ValueFromPipelinebyPropertyName=$True,Position=1)]
-    [string]$filename
+		[string]$filename,
+		[switch]$SkipData
   )
 
   PROCESS {
-    Write-Verbose filename=$filename
+	  if ($PSBoundParameters.ContainsKey("Skipdata")){$SkipFilter = "?skipdata=$($SkipData.IsPresent)"}else{$SkipFilter = ""}
+	  Write-Verbose filename=$filename
     If( [string]::IsNullOrEmpty($filename) ) {
       $file = "$id.qvf"
     } else {
       $file = $filename
     }
     Write-Verbose file=$file
-    $guid = [guid]::NewGuid()
-    $app = Invoke-QlikPost /qrs/app/$id/export/$($guid)
+	  $guid = [guid]::NewGuid()
+	  $app = Invoke-QlikPost /qrs/app/$id/export/$($guid)$SkipFilter
     Invoke-QlikDownload -path "$($app.downloadPath)" $file
     Write-Verbose "Downloaded $id to $file"
   }

--- a/resources/dataconnection.ps1
+++ b/resources/dataconnection.ps1
@@ -100,7 +100,6 @@ function Update-QlikDataConnection {
   param (
     [parameter(Mandatory=$true,ValueFromPipeline=$True,ValueFromPipelinebyPropertyName=$True,Position=0)]
     [string]$id,
-
     [string]$ConnectionString,
     [PSCredential]$Credential,
     [string[]]$customProperties,
@@ -109,10 +108,16 @@ function Update-QlikDataConnection {
 
   PROCESS {
     $qdc = Get-QlikDataConnection -raw $id
+	If ($PSBoundParameters.ContainsKey("ConnectionString")){
     $qdc.connectionstring = $ConnectionString
+	}
     if( $Credential ) {
       $qdc.username = $Credential.GetNetworkCredential().Username
-      $qdc.password = $Credential.GetNetworkCredential().Password
+	  if($qdc.psobject.Properties.name -contains "password"){
+	    $qdc.password = $Credential.GetNetworkCredential().Password
+      }else{
+        $qdc| Add-Member -MemberType NoteProperty -Name "password" -Value $($Cred.GetNetworkCredential().Password)
+      }
     }
     if( $customProperties ) { $qdc.customProperties = @(GetCustomProperties $customProperties) }
     if( $tags ) { $qdc.tags = @(GetTags $tags) }


### PR DESCRIPTION
Fix: Issue #66 - Password property missing on QDC variable
Fix: ConnectionString was set to empty string if not supplied.