### PR TITLE
Add userid/directory lookup on Update-QlikApp

### DIFF
--- a/resources/app.ps1
+++ b/resources/app.ps1
@@ -200,7 +200,10 @@ function Update-QlikApp {
     [string]$description,
     [string[]]$customProperties,
     [string[]]$tags,
-    [string]$ownername
+    [string]$ownername,
+    
+    [string]$ownerId,
+    [string]$ownerDirectory
   )
 
   PROCESS {
@@ -235,6 +238,10 @@ function Update-QlikApp {
 
     If( $ownername ) {
       $prop = Get-QlikUser -filter "name eq '$($ownername)'"
+      $app.owner = $prop
+    }
+    If( $ownerId -and $ownerDirectory ) {
+      $prop = Get-QlikUser -filter "userid eq '$($ownerId)' and userdirectory eq '$($ownerDirectory)'"
       $app.owner = $prop
     }
 


### PR DESCRIPTION
Adding in addition to username as some hosts wish to use the tool for migration (i.e. same users and directory), and username is not a required field in places like AD so isn't always populated - especially on standalone boxes