### PR TITLE
allow empty choicevalue in customproperty

### DIFF
--- a/resources/customproperty.ps1
+++ b/resources/customproperty.ps1
@@ -70,7 +70,7 @@ function Update-QlikCustomProperty {
     $prop = Get-QlikCustomProperty $id -raw
     if( $name ) { $prop.name = $name }
     if( $valueType ) { $prop.valueType = $valueType }
-    if( $choiceValues ) { $prop.choiceValues = $choiceValues }
+    if( $choiceValues -is [array]) { $prop.choiceValues = $choiceValues }
     if( $objectTypes ) { $prop.objectTypes = $objectTypes }
     $json = $prop | ConvertTo-Json -Compress -Depth 10
     return Invoke-QlikPut "/qrs/custompropertydefinition/$id" $json


### PR DESCRIPTION
Using the API it should be allowed to set the ChoiceValues in a CustomProperty to [].
I changed the line not to check if the parameter has an value (empty arrays have no value) but to check, if the paramater is an array and if, assign it.