### PR TITLE
Fix for custom property choice value with '='

### DIFF
--- a/functions/helper.ps1
+++ b/functions/helper.ps1
@@ -43,7 +43,7 @@ function FormatOutput($objects, $schemaPath) {
 function GetCustomProperties($customProperties) {
   $prop = @(
     $customProperties | Where-Object {$_} | ForEach-Object {
-      $val = $_ -Split "="
+      $val = $_.Split("=",2)
       $p = Get-QlikCustomProperty -filter "name eq '$($val[0])'"
       @{
         value = ($p.choiceValues -eq $val[1])[0]


### PR DESCRIPTION
The current implementation of GetCustomProperties breaks if one of the choice value contains  '=' character. An example would be if the choice values of a custom property consist of fully qualified  AD group names (ex - "CN=Administrators,CN=Builtin,DC=Fabrikam,DC=com" )  which are utilized in security rules (ex - "user.group = resource.app.@MyCustProp").  The fix uses  Split function overload to specify the maximum number of substrings as 2.