### PR TITLE
Changes to Connect-Qlik and Update-QlikApp

### DIFF
--- a/Qlik-Cli.psm1
+++ b/Qlik-Cli.psm1
@@ -22,7 +22,7 @@ function Connect-Qlik {
     [Parameter(ParameterSetName = "Certificate")]
     [string]$Username = "$($env:userdomain)\$($env:username)",
     # Client certificate to use for authentication
-    [parameter(ParameterSetName = "Certificate", Mandatory=$true, ValueFromPipeline=$true)]
+    [parameter(ParameterSetName = "Certificate", ValueFromPipeline=$true)]
     [System.Security.Cryptography.X509Certificates.X509Certificate]$Certificate,
     [parameter(ParameterSetName = "Certificate")]
     [ValidateSet('AppAccess', 'ManagementAccess')]

--- a/resources/app.ps1
+++ b/resources/app.ps1
@@ -208,7 +208,8 @@ function Update-QlikApp {
     [object]$owner,
     [string]$ownername,
     [string]$ownerId,
-    [string]$ownerDirectory
+    [string]$ownerDirectory,
+    [object]$stream
   )
 
   PROCESS {
@@ -229,7 +230,8 @@ function Update-QlikApp {
       $app.owner = $prop
     }
     if ($PSBoundParameters.ContainsKey("owner")) { $app.owner = GetUser $owner }
-
+    if ($PSBoundParameters.ContainsKey("stream")) { $app.stream = $stream }
+    
     $json = $app | ConvertTo-Json -Compress -Depth 10
     return Invoke-QlikPut "/qrs/app/$id" $json
   }


### PR DESCRIPTION
Removes "mandatory" property from certificate parameter so that Connect-Qlik logic (that already existed) will execute properly and search the certificate store if a certificate is not provided.

Also added the ability to update the stream in Update-QlikApp to facilitate moving apps from one stream to another.

Apologies for combining into one pull request, let me know if I should split them.