### PR TITLE
Bugfix 202003

### DIFF
--- a/functions/core.ps1
+++ b/functions/core.ps1
@@ -1,67 +1,81 @@
 $script:guid = "^(\{){0,1}[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}(\}){0,1}$"
 $script:isDate = "^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$"
-if( $qlik_output_raw ) { $rawOutput = $true }
+if ($qlik_output_raw) { $rawOutput = $true }
 
-function CallRestUri($method, $path, $extraParams) {
-  Write-Verbose "Raw output: $rawOutput"
-  If( $null -eq $Script:prefix ) { Connect-Qlik > $null }
-  If( ! $path.StartsWith( "http" ) ) {
-    $path = $Script:prefix + $path
-  }
-
-  $xrfKey = GetXrfKey
-  If( $path.contains("?") ) {
-    $path += "&xrfkey=$xrfKey"
-  } else {
-    $path += "?xrfkey=$xrfKey"
-  }
-  $params = DeepCopy $api_params
-  If( $extraParams ) { $params += $extraParams }
-  If( !$params.Header ) { $params.Header = @{} }
-  If( !$params.Header.ContainsKey("x-Qlik-Xrfkey") ) {
-    Write-Verbose "Adding header x-Qlik-Xrfkey: $xrfKey"
-    $params.Header.Add("x-Qlik-Xrfkey", $xrfKey)
-  }
-  If( $params.Body ) { Write-Verbose $params.Body }
-
-  Write-Verbose "Calling $method for $path"
-  try {
-    If( $null -eq $script:webSession ) {
-      $result = Invoke-RestMethod -Method $method -Uri $path @params -SessionVariable webSession
-      $script:webSession = $webSession
-    } elseif ($params.InFile) {
-      $ProgressPreference = 'SilentlyContinue'
-      $result = (Invoke-WebRequest -Method $method -Uri $path @params -WebSession $script:webSession).Content | ConvertFrom-Json
-    } elseif ($params.OutFile) {
-      $ProgressPreference = 'SilentlyContinue'
-      $result = Invoke-WebRequest -Method $method -Uri $path @params -WebSession $script:webSession
-    } else {
-      $result = Invoke-RestMethod -Method $method -Uri $path @params -WebSession $script:webSession
-    }
-  }
-  catch {
-    throw $_
-    return
-  }
-
-  if( !$rawOutput ) {
-    Write-Verbose "Formatting response"
-    $result = FormatOutput($result)
-  }
-
-  return $result
+function CallRestUri($method, $path, $extraParams)
+{
+	Write-Verbose "Raw output: $rawOutput"
+	If ($null -eq $Script:prefix) { Connect-Qlik > $null }
+	If (! $path.StartsWith("http"))
+	{
+		$path = $Script:prefix + $path
+	}
+	
+	$xrfKey = GetXrfKey
+	If ($path.contains("?"))
+	{
+		$path += "&xrfkey=$xrfKey"
+	}
+	else
+	{
+		$path += "?xrfkey=$xrfKey"
+	}
+	$params = DeepCopy $api_params
+	If ($extraParams) { $params += $extraParams }
+	If (!$params.Header) { $params.Header = @{ } }
+	If (!$params.Header.ContainsKey("x-Qlik-Xrfkey"))
+	{
+		Write-Verbose "Adding header x-Qlik-Xrfkey: $xrfKey"
+		$params.Header.Add("x-Qlik-Xrfkey", $xrfKey)
+	}
+	If ($params.Body) { Write-Verbose $params.Body }
+	
+	Write-Verbose "Calling $method for $path"
+	
+	try
+	{
+		$paramInvokeRestMethod = @{
+			Method	   = $method
+			Uri	       = $path
+			WebSession = $script:webSession
+		}
+		
+		If ($null -eq $script:webSession)
+		{
+			$paramInvokeRestMethod.SessionVariable = 'webSession'
+		}
+		if ($params.OutFile -or $params.InFile) { $ProgressPreference = 'SilentlyContinue' }
+		
+		$result = Invoke-RestMethod @paramInvokeRestMethod @params
+	}
+	catch
+	{
+		throw $_
+		return
+	}
+	
+	if (!$rawOutput)
+	{
+		Write-Verbose "Formatting response"
+		$result = FormatOutput($result)
+	}
+	return $result
 }
 
-function DeepCopy($data) {
-  $copy=@{}
-  $data.Keys | ForEach-Object {
-    $copy.Add($_, $(
-      if($data.$_.GetType().Name -eq 'HashTable') {
-        DeepCopy($data.$_)
-      } else {
-        $data.$_
-      }
-    ))
-  }
-  return $copy
+function DeepCopy($data)
+{
+	$copy = @{ }
+	$data.Keys | ForEach-Object {
+		$copy.Add($_, $(
+				if ($data.$_.GetType().Name -eq 'HashTable')
+				{
+					DeepCopy($data.$_)
+				}
+				else
+				{
+					$data.$_
+				}
+			))
+	}
+	return $copy
 }

--- a/resources/user.ps1
+++ b/resources/user.ps1
@@ -1,27 +1,45 @@
-function Get-QlikUser {
-  [CmdletBinding()]
-  param (
-    [parameter(Position=0,ValueFromPipelinebyPropertyName=$true)]
-    [string]$id,
-    [string]$filter,
-    [switch]$full,
-    [switch]$raw
-  )
-
-  PROCESS {
-    $path = "/qrs/user"
-    If( $id ) { $path += "/$id" }
-    If( $full ) { $path += "/full" }
-    If( $raw ) { $rawOutput = $true }
-    $result = Invoke-QlikGet $path $filter
-    if( $raw -Or $full ) {
-      return $result
-    } else {
-      $properties = @('name','userDirectory','userId','id')
-      #if( $full ) { $properties += @('roles','inactive','blacklisted','removedExternally') }
-      return $result | Select-Object -Property $properties
-    }
-  }
+function Get-QlikUser
+{
+	[CmdletBinding()]
+	param
+	(
+		[Parameter(ParameterSetName = 'ID',
+				   Mandatory = $true,
+				   ValueFromPipeline = $true,
+				   ValueFromPipelineByPropertyName = $true,
+				   Position = 0)]
+		[string]$id,
+		[string]$filter,
+		[Parameter(ParameterSetName = 'Full')]
+		[switch]$full,
+		[switch]$raw
+	)
+	
+	BEGIN
+	{
+		$path = "/qrs/user"
+		$properties = @('name', 'userDirectory', 'userId', 'id')
+	}
+	PROCESS
+	{
+		$CurrentPath = $path
+		If ($PSBoundParameters.ContainsKey("ID")) { $CurrentPath += "/$id" }
+		If ($full -eq $true) { $CurrentPath += "/full" }
+		If ($raw -eq $true) { $rawOutput = $true }
+		$paramInvokeQlikGet = @{
+			path   = $CurrentPath
+			filter = $filter
+		}
+		$result = Invoke-QlikGet @paramInvokeQlikGet
+		if (($full -eq $true) -Or ($full -eq $true) -Or $PSBoundParameters.ContainsKey("ID"))
+		{
+			return $result
+		}
+		else
+		{
+			return $result | Select-Object -Property $properties
+		}
+	}
 }
 
 function New-QlikUser {


### PR DESCRIPTION
`Core.ps1\CallRestURI` - Corrected non terminating error in Export & Import processes 

> "ConvertFrom-Json : Cannot bind argument to parameter 'InputObject' because it is null."

`Functions\User.ps1\Get-QlikUser` Updated to better support pipeline userIDs
`Functions\Content.ps1\Download-QlikContent` Added new function to export content from Libraries and Apps